### PR TITLE
fixed typo in withMeta example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ class User extends Resource
 		
 			// or
 		
-			Impersonate::make()->withMeta([
+			Impersonate::make($this)->withMeta([
 			    'redirect_to' => '/custom-redirect-url'
 			]),
 


### PR DESCRIPTION
As specified in the issue, there is a minor typo in the docs. 