### PR TITLE
Rename `user` route parameter to `id`

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -14,6 +14,6 @@ use KABBOUCHI\NovaImpersonate\Http\Controllers\ImpersonateController;
 |
 */
 
-Route::get('users/{user}', ImpersonateController::class . '@take')->middleware(['nova']);
+Route::get('users/{id}', ImpersonateController::class . '@take')->middleware(['nova']);
 
 Route::get('leave', ImpersonateController::class . '@leave')->middleware(['auth']);

--- a/src/Http/Controllers/ImpersonateController.php
+++ b/src/Http/Controllers/ImpersonateController.php
@@ -19,14 +19,14 @@ class ImpersonateController extends Controller
 		$this->manager = app()->make(ImpersonateManager::class);
 	}
 
-	public function take(Request $request, $user)
+	public function take(Request $request, $id)
 	{
 
 		if (method_exists($request->user(), 'canImpersonate') && !$request->user()->canImpersonate()) {
 			abort(403);
 		}
 
-		$user_to_impersonate = $this->manager->findUserById($user);
+		$user_to_impersonate = $this->manager->findUserById($id);
 
 
 		if (method_exists($user_to_impersonate, 'canBeImpersonated') && !$user_to_impersonate->canBeImpersonated()) {


### PR DESCRIPTION
This PR renames the `user` route parameter to `id` to avoid conflicts with implicit/explicit user model binding via `user`.