### PR TITLE
Check Response Content-Type

### DIFF
--- a/src/Http/Middleware/Impersonate.php
+++ b/src/Http/Middleware/Impersonate.php
@@ -41,7 +41,7 @@ class Impersonate
 
 			!$request->expectsJson() &&
 
-			$request->acceptsHtml()
+			starts_with($response->headers->get('Content-Type'), 'text/html')
 		) {
 
 			/** @var Response $response * */


### PR DESCRIPTION
It will be always tricky to automatically inject the reverse.blade to the response, as Content-Type can be wrongly set, unknown Class can be used etc. etc.

But at least, the actual implementation breaks Nova delivery of 3rd party Scripts. Nova delivers custom scripts in Laravel\Nova\Http\Controllers\ScriptController::show as:

```php
return response(
    file_get_contents(Nova::allScripts()[$request->script]),
    200, ['Content-Type' => 'application/javascript']
);
```

So it breaks Nova functionality if 3rd party Script must be loaded. Thus I would like to propose to check the Content Type.