### PR TITLE
Update Impersonate.php

### DIFF
--- a/src/Http/Middleware/Impersonate.php
+++ b/src/Http/Middleware/Impersonate.php
@@ -27,9 +27,9 @@ class Impersonate
 		$manager = app()->make(ImpersonateManager::class);
 
 		if (
-			auth()->check() &&
-
 			$manager->isImpersonating() &&
+			
+			auth()->check() &&
 
 			!($response instanceof RedirectResponse) &&
 


### PR DESCRIPTION
reversing the order check to prevent 419 errors in case of multi auth guard scenario

Scenario:
Consider an application with separate guards for admin and customer. 
User A is logged in as customer using 'xxxx@gmail.com'. 
User A tries login to admin area using 'yyyy@example.com'. At this point auth()->check() in the impersonate middleware resets the xsrf token. And laravel throws 419 error.

Issue can be fixed if auth check is done only after the impersonation check.
