### PR TITLE
Prevent content appending on stream responses 

### DIFF
--- a/src/Http/Middleware/Impersonate.php
+++ b/src/Http/Middleware/Impersonate.php
@@ -6,8 +6,8 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Response;
 use Lab404\Impersonate\Services\ImpersonateManager;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class Impersonate
 {
@@ -28,15 +28,15 @@ class Impersonate
 
 		if (
 			$manager->isImpersonating() &&
-			
+
 			auth()->check() &&
 
 			!($response instanceof RedirectResponse) &&
 
 			!($response instanceof BinaryFileResponse) &&
-			
+
 			!($response instanceof StreamedResponse) &&
-			
+
 			!($response instanceof JsonResponse) &&
 
 			!$request->expectsJson() &&


### PR DESCRIPTION
I have a download route getting this error message due to impersonating

## content cannot be set on a StreamedResponse instance.

```php
return \Storage::download($path);
```