### PR TITLE
Swap recording of leaving and entering impersonate actions

### DIFF
--- a/src/Http/Controllers/ImpersonateController.php
+++ b/src/Http/Controllers/ImpersonateController.php
@@ -33,16 +33,16 @@ class ImpersonateController extends Controller
             abort(403);
         }
 
-        if (config('nova-impersonate.actionable')) {
-            $this->recordAction($request->user()->getKey(), $user_to_impersonate, 'Impersonate');
-        }
-
         if (config('nova-impersonate.leave_before_impersonate') && $this->manager->isImpersonating()) {
             if (config('nova-impersonate.actionable')) {
                 $this->recordAction($this->manager->getImpersonatorId(), auth()->user(), 'Leave Impersonation');
             }
 
             $this->manager->leave();
+        }
+
+        if (config('nova-impersonate.actionable')) {
+            $this->recordAction($request->user()->getKey(), $user_to_impersonate, 'Impersonate');
         }
 
         $this->manager->take($request->user(), $user_to_impersonate);


### PR DESCRIPTION
Right now the actions are recorded wrong.

After you impersonate a user and then enter a new user, the actions are swapped.  
So you first enter the new user and then leave the old user.  
(I saw it after inspecting the ID of the actions that were taken)