### PR TITLE
Add class to fixed div to allow for custom styling and support for CSP

### DIFF
--- a/resources/views/reverse.blade.php
+++ b/resources/views/reverse.blade.php
@@ -5,7 +5,7 @@
        }
     }
 </style>
-<div class="noprint" style="
+<div class="noprint impersonate" style="
      position: fixed;
      padding: 15px 20px 15px 15px;
      min-width: 160px;

--- a/resources/views/reverse.blade.php
+++ b/resources/views/reverse.blade.php
@@ -5,7 +5,7 @@
        }
     }
 </style>
-<div class="noprint impersonate" style="
+<div class="noprint reverse-impersonate-container" style="
      position: fixed;
      padding: 15px 20px 15px 15px;
      min-width: 160px;


### PR DESCRIPTION
Currently the inline styling of the fixed div to "Reverse Impersonate" is not compliant with Content Security Policy (CSP) and is subsequently blocked, making the div invisible.  To work around this, adding a class to the div allows developers to add their own styling using CSS.  Note that this will still cause a CSP violation, but at least the div will still show when developers add this to their CSP-compliant CSS:

```
.impersonate {
  position: fixed;
  padding: 15px 20px 15px 15px;
  min-width: 160px;
  top: 25%;
  right: -5px;
  background-color: #fff;
  -webkit-box-shadow: 0 2px 4px 0 rgba(0, 0, 0, .05);
  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, .05);
  border-radius: .5rem;
  text-align: center;
  z-index: 9999;
}
```

It also allows us to add our own custom styling to the div.

