### PR TITLE
Added package route name prefix for route registration

### DIFF
--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -52,6 +52,7 @@ class ToolServiceProvider extends ServiceProvider
 
         Route::middleware(array_wrap(config('nova-impersonate.middleware.base')))
             ->prefix('nova-impersonate')
+            ->name('nova.impersonate')
             ->group(__DIR__.'/../routes/api.php');
     }
 


### PR DESCRIPTION
Nova uses `nova.`, would be nice to have when using `$ php artisan route:list`.