### PR TITLE
User may be null

### DIFF
--- a/src/Impersonate.php
+++ b/src/Impersonate.php
@@ -53,7 +53,7 @@ class Impersonate extends Field
             'enable_multi_guard' => config('nova-impersonate.enable_multi_guard'),
             'impersonator_guards' =>  config('nova-impersonate.impersonator_guards'),
             'default_impersonator_guard' =>  config('nova-impersonate.default_impersonator_guard'),
-            'impersonate_target_name' => $user->name ?? $user->email,
+            'impersonate_target_name' => $user->name ?? $user->email ?? null,
         ]);
     }
 }


### PR DESCRIPTION
Otherwise the following error is trigged in some cases:

`Trying to get property 'email' of non-object`