### PR TITLE
Retrieve ActionEvent model via ActionResource

### DIFF
--- a/src/Http/Controllers/ImpersonateController.php
+++ b/src/Http/Controllers/ImpersonateController.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Str;
 use KABBOUCHI\NovaImpersonate\Contracts\Impersonate;
-use Laravel\Nova\Actions\ActionEvent;
+use Laravel\Nova\Actions\ActionResource;
 
 class ImpersonateController extends Controller
 {
@@ -75,7 +75,7 @@ class ImpersonateController extends Controller
 
     protected function recordAction($userId, $user_to_impersonate, $actionName)
     {
-        ActionEvent::create([
+        ActionResource::newModel()->create([
             'batch_id' => (string) Str::orderedUuid(),
             'user_id' => $userId,
             'name' => $actionName,


### PR DESCRIPTION
Hello & thanks for the package.

We use a custom `ActionEvent` model to change the database connection on it. However, the model is hardcoded in the controller so it tries to persist to the main database, but fails to do so as the table does not exist in there.

Resolving the model instance via the `ActionResource` would solve this issue.

Thank you!