### PR TITLE
Ensure middleware and reverse ui uses the correct guard

### DIFF
--- a/resources/views/reverse.blade.php
+++ b/resources/views/reverse.blade.php
@@ -26,8 +26,8 @@
     "
 >
     <p>
-        @if( auth()->user()->name )
-            {{ __('Impersonating as') }} {{ auth()->user()->name }}
+        @if( auth($impersonatorGuardName)->user()->name )
+            {{ __('Impersonating as') }} {{ auth($impersonatorGuardName)->user()->name }}
         @endif
     </p>
 

--- a/src/Http/Middleware/Impersonate.php
+++ b/src/Http/Middleware/Impersonate.php
@@ -23,11 +23,11 @@ class Impersonate
         $response = $next($request);
 
         $manager = app('impersonate');
-
+        $impersonatorGuardName = $manager->getImpersonatorGuardUsingName();
         if (
             $manager->isImpersonating() &&
 
-            auth()->check() &&
+            auth($impersonatorGuardName)->check() &&
 
             ! ($response instanceof RedirectResponse) &&
 
@@ -47,7 +47,9 @@ class Impersonate
             /** @var Response $response * */
             $content = $response->getContent();
 
-            $content .= view('nova-impersonate::reverse')->render();
+            $content .= view('nova-impersonate::reverse', [
+                'impersonatorGuardName' => $impersonatorGuardName,
+            ])->render();
 
             $response->setContent($content);
         }


### PR DESCRIPTION
When dealing with multiple guards, the middleware and reverse ui doesn't know which guard is impersonated. 

Suppose you have the default `web` guard (used for accessing Nova) as well as a `customer` guard (used by customers to access your platform). You impersonate the `customer` guard but because Laravel doesn't know which guard you are using, it'll default to using the web guard. This setup means that `auth()->check()` is returning false which means that the reverse ui isn't being appended to the layout.

This PR corrects this error.