### PR TITLE
Allow to be installed in Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "license": "MIT",
     "require": {
         "php": ">=7.1.0",
-        "lab404/laravel-impersonate": "^1.4.1"
+        "lab404/laravel-impersonate": "^1.7.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Bump laravel-impersonate to v1.7.3

@KABBOUCHI Hi. This will allow to be installed in Laravel 9. 