### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
     ],
     "license": "MIT",
     "require": {
-        "php": ">=7.1.0",
         "lab404/laravel-impersonate": "^1.7.3"
     },
     "autoload": {


### PR DESCRIPTION
Laravel 9 support is busted due to this. There is no need to pin PHP to version 7 here.