### PR TITLE
Added ability to use different value for impersonating modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,21 @@ Please make sure to pass instance Model or Nova Resource ``Impersonate::make($th
         return $this->can_be_impersonated == 1;
     }
 ```
+
+By default `name` field is used for when displaying what user is impersonated at a moment.
+You need to add the method `impersonateName()` to your user model to extend this behavior:
+Please make sure to pass instance Model or Nova Resource ``Impersonate::make($this)`` ``Impersonate::make($this->resource)``
+
+```php
+    /**
+     * @return string
+     */
+    public function impersonateName()
+    {
+        // For example
+        return $this->email;
+    }
+```
 ---
 
 #### Events

--- a/resources/views/reverse.blade.php
+++ b/resources/views/reverse.blade.php
@@ -26,7 +26,9 @@
     "
 >
     <p>
-        @if( auth($impersonatorGuardName)->user()->name )
+        @if(method_exists(auth($impersonatorGuardName)->user(), 'impersonateName'))
+            {{ __('Impersonating as') }} {{ auth($impersonatorGuardName)->user()->impersonateName() }}
+        @elseif( auth($impersonatorGuardName)->user()->name )
             {{ __('Impersonating as') }} {{ auth($impersonatorGuardName)->user()->name }}
         @endif
     </p>


### PR DESCRIPTION
By default impersonating modal uses `name` field from user model to display what user it is impersonated at a moment. I have extended this behaviour and added ability to pass custom value.